### PR TITLE
replace broken slack invite with a working discord

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,7 @@
                 <a href="https://www.meetup.com/Elixir-Berlin/">The Meetup</a>
                 <a href="https://github.com/elixir-berlin/planning/issues/new?template=talk.yml">Apply as Speaker</a>
                 <a href="https://github.com/elixir-berlin/elixir-companies-berlin">Company Register</a>
-                <a href="https://join.slack.com/t/elixir-lang/shared_invite/zt-1f13hz7mb-N4KGjF523ONLCcHfb8jYgA">&#x23;Berlin</a>
+                <a href="https://discord.com/invite/WaKTXHD">&#x23;Berlin</a>
               </nav>
             </header>
           </div>
@@ -69,7 +69,7 @@
         <div class="coc">
           💜 Ethos: Read our <a href="https://github.com/elixir-berlin/planning/blob/main/Code-of-Conduct.md">Code of Conduct</a>
           <br/>
-          💬 Talk: <a href="https://join.slack.com/t/elixir-lang/shared_invite/zt-1f13hz7mb-N4KGjF523ONLCcHfb8jYgA">Join &#x23;Berlin on the Elixir Slack</a>
+          💬 Talk: <a href="https://discord.com/invite/WaKTXHD">Join us on Discord</a>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
Noticed that the slack link on elixir.berlin is broken - so here is a replace with Discord.

<img width="1252" alt="Screenshot 2024-01-04 at 15 43 53" src="https://github.com/elixir-berlin/elixir-berlin.github.io/assets/222101/b8a9fd6b-8fd7-42d1-87ad-af6dd8647f60">
